### PR TITLE
hide trending section on rhs

### DIFF
--- a/annoyances.txt
+++ b/annoyances.txt
@@ -16,3 +16,4 @@ x.com##[data-testid*=followups]:upward(1):has(path[d="M7.414 13l5.043 5.04-1.414
 x.com##[aria-label="Grok actions"]
 x.com##[data-testid="GrokDrawer"]
 x.com##[aria-label="Enhance your post with Grok"]
+x.com##div[aria-label="Trending"]>div>div:has(section>div[aria-label="Timeline: Trending now"])


### PR DESCRIPTION
i had mixed feelings on hiding this but i've decided it's cleaner without it
![image](https://github.com/user-attachments/assets/d8a64a70-5adc-422a-b0c4-5a39f7820952)
